### PR TITLE
Criação da classe para getBean através de ApplicationProviderAware

### DIFF
--- a/src/main/java/br/com/fakebank/ApplicationContextProvider.java
+++ b/src/main/java/br/com/fakebank/ApplicationContextProvider.java
@@ -1,0 +1,25 @@
+package br.com.fakebank;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext CONTEXT;
+
+    @Override
+    public void setApplicationContext(ApplicationContext context) throws BeansException {
+        ApplicationContextProvider.CONTEXT = context;
+    }
+
+    public static<T> T getBean(Class<T> tipo) {
+        return ApplicationContextProvider.CONTEXT.getBean(tipo);
+    }
+    
+    public static<T> T getBean(String qualifier, Class<T> tipo) {
+        return ApplicationContextProvider.CONTEXT.getBean(qualifier , tipo);
+    }   
+}


### PR DESCRIPTION
Disponibilização de classe para obter Bean (@Component, @Repository ou @Service) através de método estático.

Para usar, declarar atributo com `@Autowired`
```java
    @Autowired
    private ApplicationContext applicationContext;
```

Declarar o bean que desejar:
```java
    private AlgoService algoService;
```

Para obter o bean:
```java
    this.algoService = ApplicationContextProvider.getBean(AlgoService.class);
```