### PR TITLE
Adição de método de montagem de status code 201 - Created no Endpoint Abstrato

### DIFF
--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpoint.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpoint.java
@@ -27,7 +27,6 @@ public class AgenciaEndpoint extends FakebankEndpoint{
 	@Autowired
 	private AgenciaService service;
 
-	//@RequestMapping(path = "agencias", method = RequestMethod.GET)
 	@GetMapping
 	public ResponseEntity<?> listarAgencias(){
 		return ok(service.listar()); 
@@ -50,8 +49,9 @@ public class AgenciaEndpoint extends FakebankEndpoint{
 		
 	@PostMapping
 	public ResponseEntity<?> incluirAgencia(@RequestBody @Valid AgenciaInclusaoCommand comando){
-		service.salvar(comando);
-		return created("incluido com sucesso");
+		Agencia agenciaIncluida = service.salvar(comando);
+		AgenciaRepresentation model = AgenciaRepresentation.from(agenciaIncluida);
+		return created(model, agenciaIncluida.getCodigo());
 	}
 	
 	@PutMapping(value = "/{codigo}")

--- a/src/main/java/br/com/fakebank/endpoint/FakebankEndpoint.java
+++ b/src/main/java/br/com/fakebank/endpoint/FakebankEndpoint.java
@@ -1,7 +1,12 @@
 package br.com.fakebank.endpoint;
 
+import java.net.URI;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.HandlerMapping;
 
 public abstract class FakebankEndpoint {
 	
@@ -13,10 +18,29 @@ public abstract class FakebankEndpoint {
 	public <T> ResponseEntity<T> ok(T body){
 		return  ResponseEntity.ok(body);
 	}
-	
-	public <T> ResponseEntity<T> created(T body){ 
-		return new ResponseEntity<>(body, HttpStatus.CREATED);
-	}	
+
+	/***
+	 * Montar uma resposta REST HTTP para status 201 - Created
+	 * @param body Corpo de resposta para retorno
+	 * @param ids Códigos que serão retornados no 'location' do Header
+	 * @return
+	 */
+    public<T> ResponseEntity<T> created(T body, Object... ids) {
+        String pathIds = "";
+        for (Object id : ids) {
+            pathIds += "/" + id.toString();
+        }
+        
+        Object path = RequestContextHolder
+            .getRequestAttributes()
+            .getAttribute(
+                    HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE,
+                    RequestAttributes.SCOPE_REQUEST);
+        
+        URI location = URI.create(path.toString() + pathIds);
+        
+        return ResponseEntity.created(location).body(body);
+    }
 	
 	public <T> ResponseEntity<T> notFound(T body){ 
 		return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);	


### PR DESCRIPTION
Com esta implemementação no FakebankEndpoint, será possível informar o `location` do Header, com o ID do Resource que fora POSTADO.

```java
    public<T> ResponseEntity<T> created(T body, Object... ids) {
        String pathIds = "";
        for (Object id : ids) {
            pathIds += "/" + id.toString();
        }
        
        Object path = RequestContextHolder
            .getRequestAttributes()
            .getAttribute(
                    HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE,
                    RequestAttributes.SCOPE_REQUEST);
        
        URI location = URI.create(path.toString() + pathIds);
        
        return ResponseEntity.created(location).body(body);
    }
```

No método específico de Endpoint em que desejar, num @PostMapping, será possível:

```java
    @PostMapping
    public ResponseEntity<?> incluirAgencia(@RequestBody @Valid AgenciaInclusaoCommand comando) 
    {
        Agencia agenciaIncluida = service.salvar(comando);
        AgenciaRepresentation model = AgenciaRepresentation.from(agenciaIncluida);

        //O método created acionada abaixo está na classe 'Mãe' FakebankEndpoint
        //Será informado o body que é a própria agência recém incluída
        //E também o ID da agência recém incluída
        return created(model, agenciaIncluida.getCodigo());
    }
```

Repare abaixo, o atributo `location` do Header:
![image](https://user-images.githubusercontent.com/20189454/47579784-64060900-d923-11e8-98cb-00f0991cb87c.png)
