### PR TITLE
Agencia validation domain

### DIFF
--- a/src/main/java/br/com/fakebank/customValidators/AgenciaUniqueCnpjValidator.java
+++ b/src/main/java/br/com/fakebank/customValidators/AgenciaUniqueCnpjValidator.java
@@ -4,14 +4,23 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 
+import br.com.fakebank.ApplicationContextProvider;
 import br.com.fakebank.service.AgenciaService;
 
 public class AgenciaUniqueCnpjValidator implements ConstraintValidator<AgenciaUniqueCnpj, String>{
 
-	@Autowired
-	private AgenciaService service;
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    private AgenciaService service;
 	
+    @Override
+    public void initialize(AgenciaUniqueCnpj unique) {
+        this.service = ApplicationContextProvider.getBean(AgenciaService.class);
+    }
+    
 	@Override
 	public boolean isValid(String cnpj, ConstraintValidatorContext context) {
 		return !service.cnpjJaExiste(cnpj);

--- a/src/main/java/br/com/fakebank/domain/Agencia.java
+++ b/src/main/java/br/com/fakebank/domain/Agencia.java
@@ -39,7 +39,7 @@ public class Agencia {
 	
 	public static Agencia criar(AgenciaInclusaoCommand comando){
 		
-		//validate()
+		comando.validate();
 		
 		return new Agencia(comando);
 	}

--- a/src/main/java/br/com/fakebank/domain/commands/AgenciaInclusaoCommand.java
+++ b/src/main/java/br/com/fakebank/domain/commands/AgenciaInclusaoCommand.java
@@ -1,19 +1,20 @@
 package br.com.fakebank.domain.commands;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.Range;
-import org.hibernate.validator.constraints.br.CNPJ;
 
 import br.com.fakebank.customValidators.AgenciaUniqueCnpj;
 import br.com.fakebank.customValidators.CnpjValid;
+import br.com.fakebank.domain.validators.AgenciaInclusaoValidator;
+import br.com.fakebank.exceptions.FieldName;
 
 public class AgenciaInclusaoCommand {
 
 	@NotNull
 	@Range(min = 1, max = 9999)
+    @FieldName("Número")
 	private Integer numero;
 	
 	@NotNull(message = "{agencia.nome.nao.nulo}")
@@ -54,5 +55,8 @@ public class AgenciaInclusaoCommand {
 		this.cnpj = cnpj;
 	}
 	
-	
+	public void validate() {
+		AgenciaInclusaoValidator validator = new AgenciaInclusaoValidator();
+		validator.validate(this);
+	}
 }

--- a/src/main/java/br/com/fakebank/domain/validators/AbstractValidator.java
+++ b/src/main/java/br/com/fakebank/domain/validators/AbstractValidator.java
@@ -1,0 +1,70 @@
+package br.com.fakebank.domain.validators;
+
+import java.lang.reflect.Field;
+import java.util.Iterator;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+
+import br.com.fakebank.exceptions.FieldName;
+
+public abstract class AbstractValidator {
+    
+	//A classe ConstraintViolation é a classe responsável por
+	//permitir que possamos acessar as regras dos Beans Validations
+    private ConstraintViolation<?> rule;
+    
+    //Aqui, estamos expondo o Set para o ConstraintViolation
+    public void setRule(ConstraintViolation<?> rule) {
+        this.rule = rule;
+    }
+    
+    //Para obter a mensagem de erro de validação
+    protected String getMessageError() {
+        return this.rule.getMessage();
+    }
+
+    //Para obter o o campo em que o erro ocorreu 
+    protected String getFieldError() {
+        
+    	//Obtemos dois valores do ConstraintViolation
+    	//Path (que é o caminho até a propriedade)
+    	//Object (que é a propriedade em si)
+        Path path = this.rule.getPropertyPath();
+        Object obj = this.rule.getLeafBean();
+        
+        //Agora, vamos procurar o Annotation de FieldName
+        FieldName annotation = null;
+
+        for (Iterator<Path.Node> it = path.iterator(); it.hasNext();) {
+            Path.Node node = it.next();
+
+            if (ElementKind.PROPERTY.equals(node.getKind())) {
+                Field f = getField(obj.getClass(), node.getName());
+
+                if (f != null) {
+                    annotation = f.getAnnotation(FieldName.class);
+                    break;
+                }
+            }
+        }
+
+        //Caso, encontrado o FieldName, este será retornado
+        //Caso contrário, será retornado NULO
+        return annotation != null ? annotation.value() : null;
+    }
+
+    //Método privado para procurar o FieldName de forma recursiva
+    private Field getField(Class<?> type, String fieldName) {
+        while (type != null) {
+            try {
+                return type.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException nsfe) {
+                type = type.getSuperclass();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/br/com/fakebank/domain/validators/AgenciaInclusaoValidator.java
+++ b/src/main/java/br/com/fakebank/domain/validators/AgenciaInclusaoValidator.java
@@ -1,0 +1,44 @@
+package br.com.fakebank.domain.validators;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import br.com.fakebank.domain.commands.AgenciaInclusaoCommand;
+import br.com.fakebank.exceptions.MessageErrorDetail;
+import br.com.fakebank.exceptions.RequisicaoMalFormada;
+
+public class AgenciaInclusaoValidator extends AbstractValidator {
+
+    public void validate(AgenciaInclusaoCommand command) {
+    	
+        List<MessageErrorDetail> violacoes =
+        		new ArrayList<MessageErrorDetail>();
+
+        ValidatorFactory factory =
+        		Validation.buildDefaultValidatorFactory();
+        
+        Validator validator = factory.getValidator();
+
+        Set<ConstraintViolation<AgenciaInclusaoCommand>>
+        	errosEncontrados =
+                validator.validate(command);
+        
+        for (ConstraintViolation<AgenciaInclusaoCommand> error : errosEncontrados) {
+            setRule(error);
+            violacoes.add(
+            		new MessageErrorDetail(
+            				getFieldError(),
+            				getMessageError()));
+        }
+
+        if (!violacoes.isEmpty()) {
+            throw new RequisicaoMalFormada(violacoes);
+        }
+    }
+}

--- a/src/main/java/br/com/fakebank/domain/validators/AgenciaInclusaoValidator.java
+++ b/src/main/java/br/com/fakebank/domain/validators/AgenciaInclusaoValidator.java
@@ -23,7 +23,8 @@ public class AgenciaInclusaoValidator extends AbstractValidator {
         ValidatorFactory factory =
         		Validation.buildDefaultValidatorFactory();
         
-        Validator validator = factory.getValidator();
+        Validator validator =
+        		factory.getValidator();
 
         Set<ConstraintViolation<AgenciaInclusaoCommand>>
         	errosEncontrados =

--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpoint.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpoint.java
@@ -49,7 +49,7 @@ public class AgenciaEndpoint extends FakebankEndpoint{
 	}
 		
 	@PostMapping
-	public ResponseEntity<?> incluirAgencia(@RequestBody @Valid AgenciaInclusaoCommand comando){
+	public ResponseEntity<?> incluirAgencia(@RequestBody AgenciaInclusaoCommand comando){
 		service.salvar(comando);
 		return created("incluido com sucesso");
 	}

--- a/src/main/java/br/com/fakebank/exceptions/FieldName.java
+++ b/src/main/java/br/com/fakebank/exceptions/FieldName.java
@@ -1,0 +1,14 @@
+package br.com.fakebank.exceptions;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Inherited
+public @interface FieldName {
+    String value();
+}

--- a/src/main/java/br/com/fakebank/exceptions/MessageErrorDetail.java
+++ b/src/main/java/br/com/fakebank/exceptions/MessageErrorDetail.java
@@ -1,0 +1,20 @@
+package br.com.fakebank.exceptions;
+
+public class MessageErrorDetail  {
+
+    private String field;
+    private String message;
+    
+    public MessageErrorDetail (String field, String message) {
+        this.field = field;
+        this.message = message;
+    }
+    
+    public String getField() {
+        return this.field;
+    }
+    
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/br/com/fakebank/exceptions/MessageErrorResponse.java
+++ b/src/main/java/br/com/fakebank/exceptions/MessageErrorResponse.java
@@ -1,0 +1,48 @@
+package br.com.fakebank.exceptions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class MessageErrorResponse {
+
+    private LocalDateTime dataHora;
+    private String titulo;
+    private String message;
+    private List<MessageErrorDetail> messages;
+    
+    public MessageErrorResponse() {
+        this.dataHora = LocalDateTime.now();
+    }
+
+    public LocalDateTime getDataHora() {
+        return dataHora;
+    }
+
+    public void setDataHora(LocalDateTime dataHora) {
+        this.dataHora = dataHora;
+    }
+
+    public String getTitulo() {
+        return titulo;
+    }
+
+    public void setTitulo(String titulo) {
+        this.titulo = titulo;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    public List<MessageErrorDetail> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<MessageErrorDetail> messages) {
+        this.messages = messages;
+    }
+}

--- a/src/main/java/br/com/fakebank/exceptions/RequisicaoMalFormada.java
+++ b/src/main/java/br/com/fakebank/exceptions/RequisicaoMalFormada.java
@@ -1,0 +1,23 @@
+package br.com.fakebank.exceptions;
+
+import java.util.List;
+
+public class RequisicaoMalFormada extends RuntimeException {
+    
+    private List<MessageErrorDetail> errors;
+    
+    public RequisicaoMalFormada(List<MessageErrorDetail> errors) {
+        super("Erros de validação.");
+        this.errors = errors;
+    }
+
+    public RequisicaoMalFormada(String message, List<MessageErrorDetail> errors) {
+        super(message);
+        this.errors = errors;
+    }
+    
+    public List<MessageErrorDetail> getErrors() {
+        return this.errors;
+    }
+}
+

--- a/src/main/java/br/com/fakebank/exceptions/RestExceptionHandler.java
+++ b/src/main/java/br/com/fakebank/exceptions/RestExceptionHandler.java
@@ -14,4 +14,18 @@ public class RestExceptionHandler {
 		return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
 	}
 	
+    @ExceptionHandler(RequisicaoMalFormada.class)
+    public ResponseEntity<?> handleResourceBadRequestException(RequisicaoMalFormada exception) {
+        
+        MessageErrorResponse message = new MessageErrorResponse();
+        
+        message.setTitulo("Dados incorretos");
+        
+        message.setMessage(exception.getMessage());
+        
+        message.setMessages(exception.getErrors());
+        
+        return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
+    }
+
 }


### PR DESCRIPTION
Alterações no processo de validação de Domínio/Command.

As validações não serão mais validadas no `@Valid` inputado no `@RequestBody`

Voltamos a ter uma classe `AgenciaInclusaoValidator`

Agora a validação será comandada pelo domínio.

```java
    public static Agencia criar(AgenciaInclusaoCommand comando){
        comando.validate();
        return new Agencia(comando);
    }
```