### PR TITLE
Adaptação para transformar o validator em genérico

### DIFF
--- a/src/main/java/br/com/fakebank/domain/commands/AgenciaInclusaoCommand.java
+++ b/src/main/java/br/com/fakebank/domain/commands/AgenciaInclusaoCommand.java
@@ -7,7 +7,7 @@ import org.hibernate.validator.constraints.Range;
 
 import br.com.fakebank.customValidators.AgenciaUniqueCnpj;
 import br.com.fakebank.customValidators.CnpjValid;
-import br.com.fakebank.domain.validators.AgenciaInclusaoValidator;
+import br.com.fakebank.domain.validators.CommandValidator;
 import br.com.fakebank.exceptions.FieldName;
 
 public class AgenciaInclusaoCommand {
@@ -56,7 +56,10 @@ public class AgenciaInclusaoCommand {
     }
     
     public void validate() {
-        AgenciaInclusaoValidator validator = new AgenciaInclusaoValidator();
+        
+    	CommandValidator<AgenciaInclusaoCommand> validator =
+        		new CommandValidator<AgenciaInclusaoCommand>();
+        
         validator.validate(this);
     }
 }

--- a/src/main/java/br/com/fakebank/domain/validators/CommandValidator.java
+++ b/src/main/java/br/com/fakebank/domain/validators/CommandValidator.java
@@ -13,25 +13,27 @@ import br.com.fakebank.domain.commands.AgenciaInclusaoCommand;
 import br.com.fakebank.exceptions.MessageErrorDetail;
 import br.com.fakebank.exceptions.RequisicaoMalFormada;
 
-public class AgenciaInclusaoValidator extends AbstractValidator {
+public class CommandValidator<T> extends AbstractValidator {
 
-    public void validate(AgenciaInclusaoCommand command) {
+    public void validate(T command) {
     
         List<MessageErrorDetail> violacoes =
                 new ArrayList<MessageErrorDetail>();
 
-        ValidatorFactory factory =
+        ValidatorFactory factoryValidator =
                 Validation.buildDefaultValidatorFactory();
         
         Validator validator =
-                factory.getValidator();
+                factoryValidator.getValidator();
 
-        Set<ConstraintViolation<AgenciaInclusaoCommand>>
+        Set<ConstraintViolation<T>>
             errosEncontrados =
                 validator.validate(command);
         
-        for (ConstraintViolation<AgenciaInclusaoCommand> error : errosEncontrados) {
+        for (ConstraintViolation<T> error : errosEncontrados) {
+        	
             setRule(error);
+            
             violacoes.add(
                     new MessageErrorDetail(
                             getFieldError(),


### PR DESCRIPTION
Foram implementados alguns poucos ajustes para que o validator de commands, seja genérico.

Agora, para consumir a validação do Command, não será necessário criar nova classe de validação a cada comando.

Somente será necessário instanciar o Validator genérico.

Antes fazíamos assim:
```java
    public void validate() {
        
    	AgenciaInclusaoValidator validator =
        		new AgenciaInclusaoValidator();
        
        validator.validate(this);
    }
```

Agora faremos assim:
```java
    public void validate() {
        
    	CommandValidator<AgenciaInclusaoCommand> validator =
        		new CommandValidator<AgenciaInclusaoCommand>();
        
        validator.validate(this);
    }
```