### PR TITLE
Adição de DynamicUpdate para a classe de domínio Agencia

### DIFF
--- a/src/main/java/br/com/fakebank/domain/Agencia.java
+++ b/src/main/java/br/com/fakebank/domain/Agencia.java
@@ -12,11 +12,14 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.DynamicUpdate;
+
 import br.com.fakebank.domain.commands.AgenciaEdicaoCommand;
 import br.com.fakebank.domain.commands.AgenciaInclusaoCommand;
 
 @Entity
 @Table(name = "agencia", schema = "dbo")
+@DynamicUpdate(true)
 public class Agencia {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
Adicionando `@DynamicUpdate(true)` à nossa classe de domínio, o comando de UPDATE montado pelo Hibernate conterá somente os campos que sofreram alguma modificação.

Por exemplo, ao atualizar somente o campo de Número da Agência, o único campo que deveria estar no SET do UPDATE seria o NR_AGENCIA.

```java
@DynamicUpdate(true)
```

Como era antes:
```sql
    update
        dbo.agencia 
    set
        nr_agencia=?,
        nr_cnpj = ?,
        nm_agencia = ?
    where
        cd_agencia=?
```

Como será agora:
```sql
    update
        dbo.agencia 
    set
        nr_agencia=? 
    where
        cd_agencia=?
```