### PR TITLE
Versionamento de V1 e V2 na URI de Resource de Agências

### DIFF
--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV1.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV1.java
@@ -3,6 +3,7 @@ package br.com.fakebank.endpoint;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,12 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 import br.com.fakebank.domain.Agencia;
 import br.com.fakebank.domain.commands.AgenciaEdicaoCommand;
 import br.com.fakebank.domain.commands.AgenciaInclusaoCommand;
-import br.com.fakebank.representations.AgenciaRepresentation;
+import br.com.fakebank.representations.AgenciaRepresentationV1;
 import br.com.fakebank.service.AgenciaService;
 
 @RestController
-@RequestMapping("agencias")
-public class AgenciaEndpoint extends FakebankEndpoint{
+@RequestMapping({"v1/agencias", "agencias"})
+public class AgenciaEndpointV1 extends FakebankEndpoint{
     
     @Autowired
     private AgenciaService service;
@@ -30,7 +31,7 @@ public class AgenciaEndpoint extends FakebankEndpoint{
     @GetMapping
     public ResponseEntity<?> listarAgencias(){
     	List<Agencia> agencias = service.listar();
-    	List<AgenciaRepresentation> model = AgenciaRepresentation.from(agencias);
+    	List<AgenciaRepresentationV1> model = AgenciaRepresentationV1.from(agencias);
         return ok(model); 
     }
     
@@ -39,7 +40,7 @@ public class AgenciaEndpoint extends FakebankEndpoint{
     		@PathVariable("codigo") final Integer codigo){
     	
         Agencia agencia = service.consultarPorCodigo(codigo);
-        AgenciaRepresentation model = AgenciaRepresentation.from(agencia);
+        AgenciaRepresentationV1 model = AgenciaRepresentationV1.from(agencia);
         return ok(model); 
     }
     
@@ -50,7 +51,7 @@ public class AgenciaEndpoint extends FakebankEndpoint{
                 @RequestParam(value="cnpj", required=false) String cnpj){
         
     	List<Agencia> agencias = service.filtrar(nome, cnpj, numero);
-    	List<AgenciaRepresentation> model = AgenciaRepresentation.from(agencias);
+    	List<AgenciaRepresentationV1> model = AgenciaRepresentationV1.from(agencias);
         return ok(model);
     }
         
@@ -59,7 +60,7 @@ public class AgenciaEndpoint extends FakebankEndpoint{
     		@RequestBody AgenciaInclusaoCommand comando){
     	
         Agencia agenciaIncluida = service.salvar(comando);
-        AgenciaRepresentation model = AgenciaRepresentation.from(agenciaIncluida);
+        AgenciaRepresentationV1 model = AgenciaRepresentationV1.from(agenciaIncluida);
         return created(model, agenciaIncluida.getCodigo());
     }
     
@@ -69,7 +70,7 @@ public class AgenciaEndpoint extends FakebankEndpoint{
             @RequestBody AgenciaEdicaoCommand comando){
         
         Agencia agenciaEditada = service.salvar(codigo, comando);
-        AgenciaRepresentation model = AgenciaRepresentation.from(agenciaEditada);
+        AgenciaRepresentationV1 model = AgenciaRepresentationV1.from(agenciaEditada);
         return ok(model);
     }
     

--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV2.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV2.java
@@ -1,0 +1,30 @@
+package br.com.fakebank.endpoint;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import br.com.fakebank.domain.Agencia;
+import br.com.fakebank.representations.AgenciaRepresentationV2;
+import br.com.fakebank.service.AgenciaService;
+
+@RestController
+@RequestMapping("v2/agencias")
+public class AgenciaEndpointV2 extends FakebankEndpoint{
+    
+    @Autowired
+    private AgenciaService service;
+
+    @GetMapping(value = "/{codigo}")
+    public ResponseEntity<?> getAgenciaById(
+    		@PathVariable("codigo") final Integer codigo){
+    	
+        Agencia agencia = service.consultarPorCodigo(codigo);
+        AgenciaRepresentationV2 model = AgenciaRepresentationV2.from(agencia);
+        return ok(model); 
+    }
+}

--- a/src/main/java/br/com/fakebank/representations/AgenciaRepresentationV1.java
+++ b/src/main/java/br/com/fakebank/representations/AgenciaRepresentationV1.java
@@ -1,0 +1,44 @@
+package br.com.fakebank.representations;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import br.com.fakebank.domain.Agencia;
+
+public class AgenciaRepresentationV1 {
+
+    private Integer codigo;
+    private Integer numero;
+    private String nome;
+    private String cnpj;
+    
+    public static AgenciaRepresentationV1 from(Agencia agencia){
+        AgenciaRepresentationV1 model = new AgenciaRepresentationV1();
+        model.codigo = agencia.getCodigo();
+        model.numero = agencia.getNumero();
+        model.nome = agencia.getNome();
+        model.cnpj = agencia.getCnpj();
+        return model;
+    }
+    
+    public static List<AgenciaRepresentationV1> from(List<Agencia> agencias){
+    	return
+    		agencias
+    			.stream()
+    			.map(item -> from(item))
+    			.collect(Collectors.toList());
+    }
+    
+    public Integer getCodigo() {
+        return codigo;
+    }
+    public Integer getNumero() {
+        return numero;
+    }
+    public String getNome() {
+        return nome;
+    }
+    public String getCnpj() {
+        return cnpj;
+    }
+}

--- a/src/main/java/br/com/fakebank/representations/AgenciaRepresentationV2.java
+++ b/src/main/java/br/com/fakebank/representations/AgenciaRepresentationV2.java
@@ -5,21 +5,21 @@ import java.util.stream.Collectors;
 
 import br.com.fakebank.domain.Agencia;
 
-public class AgenciaRepresentation {
+public class AgenciaRepresentationV2 {
 
     private Integer codigoDaAgencia;
     private String nomeCompleto;
     private String cnpj;
     
-    public static AgenciaRepresentation from(Agencia agencia){
-        AgenciaRepresentation model = new AgenciaRepresentation();
+    public static AgenciaRepresentationV2 from(Agencia agencia){
+        AgenciaRepresentationV2 model = new AgenciaRepresentationV2();
         model.setCodigoDaAgencia(agencia.getCodigo());
         model.setNomeCompleto(agencia.getNome());
         model.setCnpj(agencia.getCnpj());
         return model;
     }
     
-    public static List<AgenciaRepresentation> from(List<Agencia> agencias){
+    public static List<AgenciaRepresentationV2> from(List<Agencia> agencias){
     	return
     		agencias
     			.stream()


### PR DESCRIPTION
Sobre versionamento há basicamente 4 tipos de versionamento possíveis em serviços REST.

- URI
- Custom Headers
- Media Types
- Request Parameter

A implementação nesta Feature está direcionada à versionamento por URI (que é um dos mais comuns)

E não há muito o que fazer:

> Se há duas versões possíveis, você precisará de dois Endpoints
Provavelmente dois Representations
E quem sabe dois Comandos

Neste caso, precisei de 2 Endpoints e 2 Representations, pois a ideia era variar o GET que recebe o Código, retornando o JSON de agência de forma diferenciada em cada uma das versões.

Agora será informado a versão na URI:

`GET /api/v1/agencias/{codigo}`
`GET /api/v2/agencias/{codigo}`

Eu também mantive a opção de não informar a versão. Neste caso usará a v1.

`GET /api/agencias/{codigo}`

```java
@RequestMapping({"v1/agencias", "agencias"})
public class AgenciaEndpointV1 extends FakebankEndpoint{
```

```java
@RequestMapping("v2/agencias")
public class AgenciaEndpointV2 extends FakebankEndpoint{
```
