### PR TITLE
Adição de arquivo de configuração de CORS

### DIFF
--- a/src/main/java/br/com/fakebank/WebConfiguration.java
+++ b/src/main/java/br/com/fakebank/WebConfiguration.java
@@ -1,0 +1,29 @@
+package br.com.fakebank;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class WebConfiguration implements WebMvcConfigurer {
+
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry
+			//addMapping recebe um pattern designando os paths aos quais estarão aplicadas
+			//as configurações aqui indicadas.
+			.addMapping("/**")
+			//allowedMethods define a lista de métodos permitidos que uma solicitação pode enviar
+			//Aqui estamos especificando os principais métodos,
+			//mas poderíamos usar "*" para liberar todos os métodos
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "CONNECT")
+			//allowedHeaders define a lista de headers que uma solicitação pode enviar
+			//no caso, estamos passando "*" para permitir o recebimento de todos os headers
+			.allowedHeaders("*")
+			//magAge indica quantos segundos a resposta de uma request pode ser armazenada pelo Client.
+			//3600 segundos = 1 hora (Valor default = 1800 segundos)
+			.maxAge(3600);
+	}
+}

--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV1.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV1.java
@@ -3,7 +3,6 @@ package br.com.fakebank.endpoint;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV2.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV2.java
@@ -1,7 +1,6 @@
 package br.com.fakebank.endpoint;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;


### PR DESCRIPTION
Neste PULL REQUEST, estamos adicionando uma configuração para permitir/liberar certos tipos de requisições aos nossos serviços.

Sem tais configurações, quando nosso serviço fosse acessado de um servidor que não seja o próprio servidor onde esteja sendo executado, receberíamos erro de acesso cruzado. Algo como:

`No 'Access-Control-Allow-Origin' header is present on the requested resource.`

Para resolver esta questão, temos de tratar o CORS (Cross-Origin Resource Sharing).

Podemos adicionar a anotação @CrossSharing aos métodos em uma classe de Endpoint...

```java
    @CrossOrigin
    @GetMapping
    public ResponseEntity<?> listarAgencias(){
    	List<Agencia> agencias = service.listar();
    	List<AgenciaRepresentationV1> model = AgenciaRepresentationV1.from(agencias);
        return ok(model); 
    }
```

... ou simplesmente anotar a própria classe.

```java
@CrossOrigin
@RestController
@RequestMapping({"v1/agencias", "agencias"})
public class AgenciaEndpointV1 extends FakebankEndpoint{
```

Na implementação de fato realizada neste PR, foi uma opção criar uma arquivo de `@Configuration` para aplicar algumas regras que se aplicação aos paths, de uma forma geral.

```java
public void addCorsMappings(CorsRegistry registry) {
	registry
		//addMapping recebe um pattern designando os paths aos quais estarão aplicadas
		//as configurações aqui indicadas.
		.addMapping("/**")
		//allowedMethods define a lista de métodos permitidos que uma solicitação pode enviar
		//Aqui estamos especificando os principais métodos,
		//mas poderíamos usar "*" para liberar todos os métodos
		.allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "CONNECT")
		//allowedHeaders define a lista de headers que uma solicitação pode enviar
		//no caso, estamos passando "*" para permitir o recebimento de todos os headers
		.allowedHeaders("*")
		//magAge indica quantos segundos a resposta de uma request pode ser armazenada pelo Client.
		//3600 segundos = 1 hora (Valor default = 1800 segundos)
		.maxAge(3600);
}
```