### PR TITLE
Melhoria do retorno de lista paginada

### DIFF
--- a/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV1.java
+++ b/src/main/java/br/com/fakebank/endpoint/AgenciaEndpointV1.java
@@ -10,7 +10,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import br.com.fakebank.domain.Agencia;
@@ -28,6 +26,7 @@ import br.com.fakebank.domain.commands.AgenciaEdicaoCommand;
 import br.com.fakebank.domain.commands.AgenciaInclusaoCommand;
 import br.com.fakebank.representations.AgenciaRepresentationV1;
 import br.com.fakebank.service.AgenciaService;
+import br.com.fakebank.util.ListaPaginada;
 
 @RestController
 @RequestMapping({"v1/agencias", "agencias"})
@@ -47,10 +46,10 @@ public class AgenciaEndpointV1 extends FakebankEndpoint{
             @ApiResponse(code = 404, message = "Nenhuma agência encontrada")
     })
     @GetMapping
-    public ResponseEntity<?> listarAgencias(){
-    	Page<Agencia> agencias = service.listar(Pageable.unpaged());
-    	List<AgenciaRepresentationV1> model = AgenciaRepresentationV1.from(agencias);
-        return ok(agencias); 
+    public ResponseEntity<?> listarAgencias(Pageable pageable){
+    	Page<Agencia> agencias = service.listar(pageable);
+    	ListaPaginada<AgenciaRepresentationV1> model = AgenciaRepresentationV1.from(agencias);
+        return ok(model); 
     }
     
     @ApiOperation(

--- a/src/main/java/br/com/fakebank/representations/AgenciaRepresentationV1.java
+++ b/src/main/java/br/com/fakebank/representations/AgenciaRepresentationV1.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 
 import br.com.fakebank.domain.Agencia;
+import br.com.fakebank.util.ListaPaginada;
 
 @ApiModel(description = "Classe de modelo (representação de agência).")
 public class AgenciaRepresentationV1 {
@@ -39,12 +40,21 @@ public class AgenciaRepresentationV1 {
     			.collect(Collectors.toList());
     }
     
-    public static List<AgenciaRepresentationV1> from(Page<Agencia> agencias){
-    	return
-    		agencias
-    			.stream()
-    			.map(item -> from(item))
-    			.collect(Collectors.toList());
+    public static ListaPaginada<AgenciaRepresentationV1> from(Page<Agencia> agencias){
+        
+        ListaPaginada<AgenciaRepresentationV1> lista =
+                new ListaPaginada<AgenciaRepresentationV1>();
+
+        lista.setContent(agencias
+                			.stream()
+                			.map(item -> from(item))
+                			.collect(Collectors.toList()));
+        
+        lista.setTotalPages(agencias.getTotalPages());
+        lista.setPageNumber(agencias.getPageable().getPageNumber());
+        lista.setPageSize(agencias.getPageable().getPageSize());
+        
+        return lista;
     }
     
     public Integer getCodigo() {


### PR DESCRIPTION
Inicialmente havíamos usado o Page<T> como retorno de uma lista paginada.

Entretanto, apesar de bem interessante, neste objeto há uma série de propriedades que num primeiro momento podem ser desnecessárias.

Este PR é para criar um objeto mais simplificado chamado ListaPaginada<T> somente com informações que neste momento são relevantes.

![image](https://user-images.githubusercontent.com/20189454/48616389-9c28c680-e97a-11e8-80cf-a9957a07570e.png)
